### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,14 +6,14 @@
 #Datatypes (KEYWORD1)
 ######################################
 
-AutomationShield  KEYWORD1
-Opto  KEYWORD1
-AutomationShield  KEYWORD1
-OptoShield  KEYWORD1
-FloatShield KEYWORD1
-HeatShield  KEYWORD1
-MotoShield  KEYWORD1
-MagnetoShield KEYWORD1
+AutomationShield	KEYWORD1
+Opto	KEYWORD1
+AutomationShield	KEYWORD1
+OptoShield	KEYWORD1
+FloatShield	KEYWORD1
+HeatShield	KEYWORD1
+MotoShield	KEYWORD1
+MagnetoShield	KEYWORD1
 
 ######################################
 #Methods and Functions (KEYWORD2)
@@ -24,20 +24,20 @@ sensorRead	KEYWORD2
 actuatorWrite	KEYWORD2
 referenceRead	KEYWORD2
 
-pid KEYWORD2 
-pidInc  KEYWORD2
+pid	KEYWORD2 
+pidInc	KEYWORD2
 
-constrainFloat  KEYWORD2
-mapFloat  KEYWORD2
+constrainFloat	KEYWORD2
+mapFloat	KEYWORD2
 
-initialize  KEYWORD2
-debug KEYWORD2
-referencePercent  KEYWORD2
-positionPercent KEYWORD2
-ventInPercent KEYWORD2
-manualControl KEYWORD2
-positionMillimeter  KEYWORD2
-calibrate KEYWORD2
+initialize	KEYWORD2
+debug	KEYWORD2
+referencePercent	KEYWORD2
+positionPercent	KEYWORD2
+ventInPercent	KEYWORD2
+manualControl	KEYWORD2
+positionMillimeter	KEYWORD2
+calibrate	KEYWORD2
 
 ######################################
 #Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords