### PR TITLE
DUE ADC12-bit

### DIFF
--- a/src/AutomationShield.h
+++ b/src/AutomationShield.h
@@ -1,16 +1,13 @@
 /*
   AutomationShield API
-
   This library serves as an API for the AutomationShield 
   ecosystem of Arduino Shields used for control engineering and
   mechatronics education.
-
   This code is part of the AutomationShield hardware and software
   ecosystem. Visit http://www.automationshield.com for more
   details. This code is licensed under a Creative Commons
   Attribution-NonCommercial 4.0 International License.
-
-  Created by Gergely Tak√°cs, Tibor Konkoly, G√°bor Penzinger
+  Created by Gergely Tak·cs, Tibor Konkoly, G·bor Penzinger
   Last update: 31.09.2018.
 */
 
@@ -29,10 +26,17 @@
 
 // THESE ARE NOT VISIBLE OUTSIDE THE SCOPE OF THE FILE, DO WE NEED THEM?
 // Common definitions
-#define AREF 5.0 // ADC reference voltage for 5 V logic
-#define ARES AREF/1023.0 // ADC resolution for 5 V logic
-#define AREF3V3 3.3 // ADC reference voltage for 3.3 V logic
-#define ARES3V3 AREF3V3/1023.0 // ADC resolution for 3.3 V logic
+#ifdef ARDUINO_ARCH_AVR                     // Chip uses 10-bit ADC
+	#define ADCREF 1023.0					// 10-bit resolution for AD convertor
+#elif ARDUINO_ARCH_SAMD || ARDUINO_ARCH_SAM // Chip uses 12-bit ADC
+	#define ADCREF 4095.0					// 12-bit resolution for AD convertor
+#endif
+
+#define AREF 5.0                              // ADC reference voltage for 5 V logic
+#define ARES AREF/ADCREF                      // ADC resolution for 5 V logic
+#define AREF3V3 3.3                           // ADC reference voltage for 3.3 V logic
+#define ARES3V3 AREF3V3/ADCREF                // ADC resolution for 3.3 V logic
+
 #define ABSZERO 273.15 // Absolute zero in Celsius 
 
 // Diagnostics
@@ -52,3 +56,4 @@
 extern AutomationShieldClass AutomationShield; // Declare external instance
 
 #endif // End of AutomationShield library.
+

--- a/src/MagnetoShield.cpp
+++ b/src/MagnetoShield.cpp
@@ -26,8 +26,11 @@ void MagnetoShieldClass::begin(){
 			analogReference(EXTERNAL);
 		#endif
 	#elif ARDUINO_ARCH_SAM
+		analogReadResolution(12);
 		Wire1.begin();
+		
 	#elif ARDUINO_ARCH_SAMD
+		analogReadResolution(12);
 		Wire.begin();
 	#endif
 }
@@ -104,7 +107,11 @@ void MagnetoShieldClass::calibration(){
 	}
 	// Selects maximum ADC value to filter for any noise.
 	// Magnet cannot get physically higher than ceiling
-	dacWrite(255);				// Full power to magnet
+	#if SHIELDRELEASE == 1 || SHIELDRELEASE == 2
+	dacWrite(255);				// Full power to magnet for 8-bit DAC
+	#elif SHIELDRELEASE == 3
+	dacWrite(4095);				// Full power to magnet for 12-bit DAC
+	#endif
 	delay(500);					   			    // Wait for things to settle
 	maxCalibrated = analogRead(MAGNETO_YPIN);	// overwrite default values -> independency of the meassurement from default saturation	
 	for (int i=1; i<=100; i++) {				// Perform 100 measurements
@@ -218,7 +225,7 @@ float MagnetoShieldClass::gaussToDistance(float g){
 #if SHIELDRELEASE == 2 || SHIELDRELEASE == 3
 	// Default sensor reading method
 	float MagnetoShieldClass::referenceRead(){	
-		return  (AutomationShield.mapFloat(analogRead(MAGNETO_RPIN),0.0,1024.0,0.0,100.0));
+		return  (AutomationShield.mapFloat(analogRead(MAGNETO_RPIN),0.0,ADCREF,0.0,100.0));
 	}
 	
 	// Reads the voltage on the Electromagnet

--- a/src/MagnetoShield.h
+++ b/src/MagnetoShield.h
@@ -65,11 +65,21 @@
 	#define A1302_LSAT	19							// [10-bit ADC] Lower saturation of the Hall sensor
 	#define A1302_HSAT 382							// [10-bit ADC] Higher (upper) saturation of the Hall sensor
 #elif SHIELDRELEASE == 2
-	#define A1302_LSAT	30							// [10-bit ADC] Lower saturation of the Hall sensor
-	#define A1302_HSAT 586							// [10-bit ADC] Higher (upper) saturation of the Hall sensor
+	#ifdef ARDUINO_ARCH_AVR
+		#define A1302_LSAT	30							// [10-bit ADC] Lower saturation of the Hall sensor
+		#define A1302_HSAT 586							// [10-bit ADC] Higher (upper) saturation of the Hall sensor
+	#elif ARDUINO_ARCH_SAMD || ARDUINO_ARCH_SAM
+		#define A1302_LSAT	120							// [12-bit ADC] Lower saturation of the Hall sensor
+		#define A1302_HSAT 2346							// [12-bit ADC] Higher (upper) saturation of the Hall sensor
+	#endif
 #elif SHIELDRELEASE == 3
-	#define A1302_LSAT	28							// [10-bit ADC] Lower saturation of the Hall sensor
-	#define A1302_HSAT 631							// [10-bit ADC] Higher (upper) saturation of the Hall sensor
+	#ifdef ARDUINO_ARCH_AVR
+		#define A1302_LSAT	28							// [10-bit ADC] Lower saturation of the Hall sensor
+		#define A1302_HSAT 631							// [10-bit ADC] Higher (upper) saturation of the Hall sensor
+	#elif ARDUINO_ARCH_SAMD || ARDUINO_ARCH_SAM
+		#define A1302_LSAT	112							// [12-bit ADC] Lower saturation of the Hall sensor
+		#define A1302_HSAT 2526							// [12-bit ADC] Higher (upper) saturation of the Hall sensor
+	#endif
 #endif
 
 // Gain constants for current and voltage measurements
@@ -111,7 +121,7 @@ public:
 	void begin(); 								// Initializes "Wire" library
 	void calibration();							// Finds out lowest and highest positions of magnet
 	#if SHIELDRELEASE == 1 || SHIELDRELEASE == 2
-	void dacWrite(uint8_t dacIn);			    	// Writes dacIn to DAC chip
+	void dacWrite(uint8_t DAClevel);			    	// Writes dacIn to DAC chip
 	uint8_t voltageToDac(float vOut);		   		// Computes DAC levels for magnet voltage based on MOSFET characteristic
 	#endif
 	


### PR DESCRIPTION
Chnage in calibration function - was wrong, default values based on board type
AutomationShield - now calculate with resolution of analog pins 12-bit
MagnetoShield - in begin() function is set 12-bit resolution for analog inputs
and correction of percents calculation based on board type