### PR TITLE
noServo sampling for MEGA fix

### DIFF
--- a/src/Sampling.h
+++ b/src/Sampling.h
@@ -37,6 +37,7 @@ SamplingNoServo::SamplingClass Sampling;
 	#include "sampling/SamplingUNO_ISR.h"
 
 #elif ARDUINO_AVR_MEGA2560
+  #define MEGA_ISR_VECT TIMER5_COMPA_vect
 	#include "sampling/SamplingMEGA_ISR.h"
     
 #elif (defined(ARDUINO_SAMD_ZERO) || defined(ADAFRUIT_METRO_M4_EXPRESS))

--- a/src/SamplingServo.h
+++ b/src/SamplingServo.h
@@ -37,6 +37,7 @@ SamplingServo::SamplingClass Sampling;
 	#include "sampling/SamplingUNO_ISR.h"
 
 #elif ARDUINO_AVR_MEGA2560
+  #define MEGA_ISR_VECT TIMER2_COMPA_vect
 	#include "sampling/SamplingMEGA_ISR.h"
     
 #elif (defined(ARDUINO_SAMD_ZERO) || defined(ADAFRUIT_METRO_M4_EXPRESS))

--- a/src/sampling/SamplingMEGA_ISR.h
+++ b/src/sampling/SamplingMEGA_ISR.h
@@ -13,7 +13,7 @@
 #ifndef SAMPLINGMEGA_ISR_H
 #define SAMPLINGMEGA_ISR_H
 
-ISR(TIMER2_COMPA_vect)
+ISR(MEGA_ISR_VECT)
 {
  if (!Sampling.fireFlag){                   // If not over the maximal resolution of the counter
   (Sampling.getInterruptCallback())();      // Start the interrupt callback


### PR DESCRIPTION
fixed switching between Timer2 and Timer5 for sampling, regarding the usage of the servo library