### PR TITLE
Bumped spell-check action to latest version (0.19.0)

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -15,8 +15,8 @@ jobs:
         with:
          ignore-words-list: etc/codespell-ignore-words-list.txt
         #skip-paths: src/lib #not necessary since submodules are not pulled in
-      
-      - name: Spell Check Python (w/ PySpelling) 
-        uses: rojopolis/spellcheck-github-actions@0.13.0
+
+      - name: Spell Check Python (w/ PySpelling)
+        uses: rojopolis/spellcheck-github-actions@0.19.0
         with:
          task_name: Python


### PR DESCRIPTION
Hello,

I have just [released 0.19.0 of the GitHub Spellcheck Action](https://dev.to/jonasbn/releases-0190-of-spellcheck-github-action-a-security-release-599k) and I noticed that older versions of the Docker image had been pulled from DockerHub recently. 

I was able to locate your configuration via [SourceGraph](https://sourcegraph.com/github.com/gergelytakacs/AutomationShield/-/blob/.github/workflows/spell-check.yml), so I am providing you with a PR proposing an update to a more contemporary version.

It should be backwards compatible even though a lot has happened, but if you experience any issue with the PR please let me know and I will comply.

Take care and stay safe,

jonasbn