### PR TITLE
Indented problematic YAML in the spellcheck configuration file

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -11,9 +11,9 @@ matrix:
     encoding: utf-8
   pipeline:
   - pyspelling.filters.python:
-    comments: true
-    docstrings: true
-    group_comments: true
-    decode_escapes: true
-    strings: false
-    string_types: fu
+      comments: true
+      docstrings: true
+      group_comments: true
+      decode_escapes: true
+      strings: false
+      string_types: fu


### PR DESCRIPTION
Oh, I overlooked that - with the more recent versions of `pyspelling` it would fail. I have tested it locally now and was able to reproduce the error. It has been addressed in this PR addressing the issue introduced with #282 